### PR TITLE
fix: __MACOS folder

### DIFF
--- a/streamlit_midi_mapper.py
+++ b/streamlit_midi_mapper.py
@@ -210,6 +210,7 @@ if st.session_state["preset_uploaded"]:
             st.session_state["uploaded_outfiles"] is not None
             and st.session_state["disable_outfile_upload"] is False
         ):
+
             with NamedTemporaryFile(
                 suffix=".zip",
                 prefix=st.session_state["uploaded_outfiles"].name,
@@ -352,7 +353,6 @@ if st.session_state["disable_outfile_upload"]:
                     cleanup=True,
                 )
             st.success("Mapping completed successfully.")
-            cleanup_temp_folders()
 
         except Exception as e:
             st.error(f"Error during mapping: {e}")
@@ -363,7 +363,7 @@ if st.session_state["disable_outfile_upload"]:
 # 5 Download Button
 ######################################
 if st.session_state["zip_output"] is not None:
-
+    cleanup_temp_folders()
     st.markdown(
         """
     ## 5 Download your mapped files

--- a/tenten_zip_utils.py
+++ b/tenten_zip_utils.py
@@ -75,6 +75,8 @@ def unzip_files(zip_name, extract_to, file_extension=None):
         file_paths = []
         for root, _, files in os.walk(extract_to):
             for file in files:
+                if "__MACOSX" in file:
+                    continue
                 if file.endswith(file_extension):
                     file_paths.append(os.path.join(root, file))
         return file_paths


### PR DESCRIPTION
mapping crashed when __MACOS folder files were present.
fix:
- skip them when extracting
- add exception handling for processing files