### PR TITLE
feat: map also fixed midi settings and midimap for Razzmatazz

### DIFF
--- a/models.py
+++ b/models.py
@@ -15,9 +15,24 @@ class BlackboxPadParam(str, Enum):
     OUTPUTBUS = "outputbus"
 
 
-BB_PAD_PARAM_DESCRIPTION = {
+class ModSources(str, Enum):
+    MIDICC = "midicc"
+    VELOCITY = "velocity"
+    MIDIVOLUME = "midivol"
+    MIDIPAN = "midipan"
+    MODWHEEL = "modwheel"
+    PITCHBEND = "pitchbend"
+
+
+DISPLAY_NAMES = {
     BlackboxPadParam.MIDIMODE: "MIDI mode",
     BlackboxPadParam.OUTPUTBUS: "Output bus",
+    ModSources.MIDICC: "MIDI CC",
+    ModSources.VELOCITY: "Velocity",
+    ModSources.MIDIVOLUME: "MIDI Volume",
+    ModSources.MIDIPAN: "MIDI Pan",
+    ModSources.MODWHEEL: "Mod Wheel",
+    ModSources.PITCHBEND: "Pitch Bend",
 }
 
 
@@ -39,6 +54,10 @@ class BlackboxSettings(BaseModel):
     noteseq_params: list = Field(default_factory=list)
 
 
+class GeneralMidiSettings(BaseModel):
+    mod_sources: list = Field(default_factory=list)
+
+
 TENTEN_EXTENSIONS = {
     "blackbox": "xml",
     "lemondrop": "nnl",
@@ -49,3 +68,27 @@ TENTEN_EXTENSIONS = {
 
 # the products for which we require to upload zip files
 TENTEN_ZIP_PRODUCTS = [TenTenDevice.BLACKBOX, TenTenDevice.TANGERINE]
+
+# these products hava block of midi mappings under `midimap` with the
+# node names `mapitem`
+TENTEN_MIDIMAP_ITEMS = [TenTenDevice.RAZZMATAZZ]
+
+# these products have a cell with the coordinates
+# row`, `column` and `layer`
+TENTEN_ROW_COLUMN_LAYER = [
+    TenTenDevice.BLACKBOX,
+    TenTenDevice.TANGERINE,
+    TenTenDevice.LEMONDROP,
+    TenTenDevice.FIREBALL,
+]
+
+# these products have a cell with the coordinates
+# row`, `column` and `synth`
+TENTEN_ROW_COLUMN_SYNTH = [
+    TenTenDevice.RAZZMATAZZ,
+]
+
+# checkboxes will be set to false for the keys in this list
+DEFAULT_FALSE_CHECKBOX = [
+    BlackboxPadParam.OUTPUTBUS,
+]

--- a/models.py
+++ b/models.py
@@ -5,6 +5,9 @@ from enum import Enum
 class TenTenDevice(str, Enum):
     BLACKBOX = "blackbox"
     LEMONDROP = "lemondrop"
+    FIREBALL = "fireball"
+    RAZZMATAZZ = "razzmatazz"
+    TANGERINE = "tangerine"
 
 
 class BlackboxPadParam(str, Enum):
@@ -25,9 +28,9 @@ class BlackboxNoteseqParam(str, Enum):
 
 
 BB_NOTESEQ_PARAM_DESCRIPTION = {
-    BlackboxNoteseqParam.SEQPADMAPDEST: "Seq pad map destination",
-    BlackboxNoteseqParam.MIDIOUTCHAN: "MIDI out channel",
-    BlackboxNoteseqParam.MIDISEQCELLCHAN: "MIDI seq cell channel",
+    BlackboxNoteseqParam.SEQPADMAPDEST: "Sequence Pad Destination",
+    BlackboxNoteseqParam.MIDIOUTCHAN: "MIDI Out Channel",
+    BlackboxNoteseqParam.MIDISEQCELLCHAN: "MIDI Sequence Cell Channel",
 }
 
 
@@ -39,7 +42,10 @@ class BlackboxSettings(BaseModel):
 TENTEN_EXTENSIONS = {
     "blackbox": "xml",
     "lemondrop": "nnl",
+    "fireball": "nnf",
+    "razzmatazz": "nnr",
+    "tangerine": "xml",
 }
 
 # the products for which we require to upload zip files
-TENTEN_ZIP_PRODUCTS = [TenTenDevice.BLACKBOX]
+TENTEN_ZIP_PRODUCTS = [TenTenDevice.BLACKBOX, TenTenDevice.TANGERINE]

--- a/tenten_zip_utils.py
+++ b/tenten_zip_utils.py
@@ -75,7 +75,7 @@ def unzip_files(zip_name, extract_to, file_extension=None):
         file_paths = []
         for root, _, files in os.walk(extract_to):
             for file in files:
-                if "__MACOSX" in file:
+                if "__MACOSX" in file or "_preset.xml" in file:
                     continue
                 if file.endswith(file_extension):
                     file_paths.append(os.path.join(root, file))

--- a/test_midi_mapper.py
+++ b/test_midi_mapper.py
@@ -6,10 +6,21 @@ import models
 
 class TestBlackbox(unittest.TestCase):
     def test_blackbox_all_settings(self):
+
+        general_midi_settings = models.GeneralMidiSettings(
+            mod_sources=[
+                models.ModSources.MIDICC,
+                models.ModSources.VELOCITY,
+                models.ModSources.MIDIVOLUME,
+                models.ModSources.MIDIPAN,
+                models.ModSources.MODWHEEL,
+                models.ModSources.PITCHBEND,
+            ]
+        )
         bsettings = models.BlackboxSettings(
             pad_params=[
                 models.BlackboxPadParam.MIDIMODE,
-                models.BlackboxPadParam.OUTPUT_BUS,
+                models.BlackboxPadParam.OUTPUTBUS,
             ],
             noteseq_params=[
                 models.BlackboxNoteseqParam.SEQPADMAPDEST,
@@ -17,17 +28,19 @@ class TestBlackbox(unittest.TestCase):
                 models.BlackboxNoteseqParam.MIDISEQCELLCHAN,
             ],
         )
-        infile = "./test_files/blackbox/XWOEAGAIN 10 A203/preset.xml"
+        infile = "./test_files/blackbox/XWOEAGAIN 12/preset.xml"
         outfiles = [
-            "./test_files/blackbox/SL AMBIENT DRONES/preset.xml",
-            "./test_files/blackbox/SL BASS MUSIC KIT/preset.xml",
-            "./test_files/blackbox/SL DARK AMBIENT/preset.xml",
+            "./test_files/blackbox/MM SL AMBIENT DRONES/preset.xml",
+            "./test_files/blackbox/MM SL BASS MUSIC KIT/preset.xml",
+            "./test_files/blackbox/MM SL DARK AMBIENT/preset.xml",
         ]
         mm = MidiMapper(
             infile=infile,
             outfiles=outfiles,
             tenten_device=models.TenTenDevice.BLACKBOX,
-            settings=bsettings,
+            device_settings=bsettings,
+            general_midi_settings=general_midi_settings,
+            overwrite_files=False,
         )
         mm.run()
         # TODO add some actual tests
@@ -60,10 +73,36 @@ class TestBlackbox(unittest.TestCase):
                 infile=infile,
                 outfiles=outfiles,
                 tenten_device=models.TenTenDevice.BLACKBOX,
-                settings=RandomClass(),  # This should cause a mismatch
+                device_settings=RandomClass(),  # This should cause a mismatch
             ),
         )
 
 
-class TestLemondrop(unittest.TestCase):
-    def test_lemondrop(self): ...
+class TestRazzmatazz(unittest.TestCase):
+    def test_razzmatazz_all_settings(self):
+        general_midi_settings = models.GeneralMidiSettings(
+            mod_sources=[
+                models.ModSources.MIDICC,
+                models.ModSources.VELOCITY,
+                models.ModSources.MIDIVOLUME,
+                models.ModSources.MIDIPAN,
+                models.ModSources.MODWHEEL,
+                models.ModSources.PITCHBEND,
+            ]
+        )
+
+        infile = "./test_files/razzmatazz/mapped/002BoomClap MIDI V2.nnr"
+        outfiles = [
+            "./test_files/razzmatazz/mapped/002BoomClap MIDI test.nnr",
+            "./test_files/razzmatazz/mapped/002BoomClap.nnr",
+            "./test_files/razzmatazz/001AeroVan.nnr",
+        ]
+        mm = MidiMapper(
+            infile=infile,
+            outfiles=outfiles,
+            tenten_device=models.TenTenDevice.RAZZMATAZZ,
+            general_midi_settings=general_midi_settings,
+            overwrite_files=False,
+        )
+        mm.run()
+        # TODO add some actual tests


### PR DESCRIPTION
- remove wipe midi settings option, now it's always wiped
- transfer not only `midicc`, but also modwheel, pitchbend etc
- transfer the `midimap` block for razzmatazz devices